### PR TITLE
WIP: Add command line args and docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Local build artifacts
+target
+
+# Docker files
+Dockerfile*
+docker-compose*
+
+# IDE files
+.vscode
+.idea
+*.iml
+
+# Git folder
+.git
+
+# Dot files
+.env
+.gitignore
+
+# Documentation
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,85 @@
+# Using multistage build:
+# 	https://docs.docker.com/develop/develop-images/multistage-build/
+# 	https://whitfin.io/speeding-up-rust-docker-builds/
+
+
+##########################  BUILD IMAGE  ##########################
+# Musl build image to build portals statically compiled binary
+FROM rust:1.47.0-alpine3.12 as builder
+
+# Don't download Rust docs
+RUN rustup set profile minimal
+
+ENV USER "migrator"
+ENV RUSTFLAGS='-C link-arg=-s'
+
+
+# Install packages needed for building all crates
+RUN apk add --no-cache \
+        musl-dev
+
+# Specifies if the local project is build or if Conduit gets build
+# from the official git repository. Defaults to the git repo.
+ARG LOCAL=false
+# Specifies which revision/commit is build. Defaults to HEAD
+ARG GIT_REF=origin/master
+
+# Add musl target, as we want to run our project in
+# an alpine linux image
+#RUN rustup target add x86_64-unknown-linux-musl
+
+# Copy project files from current folder
+COPY . .
+# Build it from the copied local files or from the official git repository
+RUN if [[ $LOCAL == "true" ]]; then \
+        cargo install --path . ; \
+    else \
+        cargo install --git "https://github.com/Weasy666/sled-migrator.git" --rev ${GIT_REF}; \
+    fi
+
+########################## RUNTIME IMAGE ##########################
+# Create new stage with a minimal image for the actual
+# runtime image/container
+FROM alpine:3.12
+
+ARG CREATED
+ARG VERSION
+ARG GIT_REF=HEAD
+
+# Labels according to https://github.com/opencontainers/image-spec/blob/master/annotations.md
+# including a custom label specifying the build command
+LABEL org.opencontainers.image.created=${CREATED} \
+      org.opencontainers.image.authors="Conduit Contributors" \
+      org.opencontainers.image.title="Conduit" \
+      org.opencontainers.image.version=${VERSION} \
+      org.opencontainers.image.vendor="Conduit Contributors" \
+      org.opencontainers.image.description="A migration tool to upgrade Conduit's Sled database" \
+      org.opencontainers.image.url="https://conduit.rs/" \
+      org.opencontainers.image.revision=${GIT_REF} \
+      org.opencontainers.image.source="https://github.com/timokoesters/sled-migrator.git" \
+      org.opencontainers.image.licenses="AGPL-3.0-only" \
+      org.opencontainers.image.documentation="" \
+      org.opencontainers.image.ref.name="" \
+      org.label-schema.docker.build="docker build . -t matrixconduit/sled-migrator:latest --build-arg CREATED=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg VERSION=$(grep -m1 -o '[0-9].[0-9].[0-9]' Cargo.toml)" \
+      maintainer="Weasy666"
+
+# Copy config files from context and the binary from
+# the "builder" stage to the current stage into folder
+# /srv/conduit and create data folder for database
+RUN mkdir -p /srv/conduit/.local/share/conduit
+COPY --from=builder /usr/local/cargo/bin/sled-migrator /srv/conduit/
+
+# Add www-data user and group with UID 82, as used by alpine
+# https://git.alpinelinux.org/aports/tree/main/nginx/nginx.pre-install
+RUN set -x ; \
+    addgroup -Sg 82 www-data 2>/dev/null ; \
+    adduser -S -D -H -h /srv/conduit -G www-data -g www-data www-data 2>/dev/null ; \
+    addgroup www-data www-data 2>/dev/null && exit 0 ; exit 1
+
+# Change ownership of Conduit files to www-data user and group
+RUN chown -cR www-data:www-data /srv/conduit
+
+# Set user to www-data
+USER www-data
+# Set container home directory
+WORKDIR /srv/conduit

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY . .
 RUN if [[ $LOCAL == "true" ]]; then \
         cargo install --path . ; \
     else \
-        cargo install --git "https://github.com/Weasy666/sled-migrator.git" --rev ${GIT_REF}; \
+        cargo install --git "https://github.com/timokoesters/sled-migrator.git" --rev ${GIT_REF}; \
     fi
 
 ########################## RUNTIME IMAGE ##########################
@@ -76,7 +76,7 @@ RUN set -x ; \
     adduser -S -D -H -h /srv/conduit -G www-data -g www-data www-data 2>/dev/null ; \
     addgroup www-data www-data 2>/dev/null && exit 0 ; exit 1
 
-# Change ownership of Conduit files to www-data user and group
+# Change ownership of sled-migrator to www-data user and group
 RUN chown -cR www-data:www-data /srv/conduit
 
 # Set user to www-data

--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ The program will ask for the input path (path of your current sled db), the
 output path (path where you want the migrated sled db to be) and the target
 sled version (one of [0.31, 0.32, 0.33, 0.34]) and will upgrade the db to that
 version.
+
+Or you can provide the values directly as parameters
+```bash
+cargo run --release -- --input=${PATH_TO_DB} --output=${OUTPUT_PATH} --target=0.34
+```

--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ Or you can provide the values directly as parameters
 ```bash
 cargo run --release -- --input=${PATH_TO_DB} --output=${OUTPUT_PATH} --target=0.34
 ```
+
+### Docker
+
+```bash
+docker run --rm --volume ${NAME_OF_YOUR_CONDUIT_DATA_VOLUME}:/srv/conduit/.local/share/conduit matrixconduit/sled-migrator:latest /srv/conduit/sled-migrator --input=/srv/conduit/.local/share/conduit/${DOMAIN_NAME} --output=/srv/conduit/.local/share/conduit/${DOMAIN_NAME} --target=0.34
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,6 @@ fn main() {
 
     let data: Vec<_> = sled_0_31::Config::default()
         .path(input.clone())
-        .temporary(true)
         .open()
         .ok()
         .filter(|db| db.was_recovered())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,49 @@
-use std::io::{stdin, stdout, Write};
+use std::{env, io::{stdin, stdout, Write}};
+use std::collections::BTreeMap;
 
 fn main() {
     let mut input = String::new();
     let mut output = String::new();
     let mut target = String::new();
 
-    print!("Input path: ");
-    stdout().flush().unwrap();
-    stdin().read_line(&mut input).unwrap();
+    let args: BTreeMap<String, String> = env::args()
+        .filter(|arg| arg.starts_with("-"))
+        .map(|arg| {
+            arg.splitn(2, '=')
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .fold(BTreeMap::new(), |mut map, arg| {
+            if arg.len() != 2 {
+                panic!("Wrong argument! An argument must be of the format 'key=value'");
+            }
+            map.insert(arg[0].trim_start_matches('-').to_owned(), arg[1].to_owned());
+            map
+        });
 
-    print!("Output path: ");
-    stdout().flush().unwrap();
-    stdin().read_line(&mut output).unwrap();
+    if let Some(input_path) = args.get("input") {
+        input = input_path.to_owned();
+    } else {
+        print!("Input path: ");
+        stdout().flush().unwrap();
+        stdin().read_line(&mut input).unwrap();
+    }
 
-    print!("Target sled version [0.34]: ");
-    stdout().flush().unwrap();
-    stdin().read_line(&mut target).unwrap();
+    if let Some(output_path) = args.get("output") {
+        output = output_path.to_owned();
+    } else {
+        print!("Output path: ");
+        stdout().flush().unwrap();
+        stdin().read_line(&mut output).unwrap();
+    }
 
-    input = input.trim().to_owned();
-    output = output.trim().to_owned();
-    target = target.trim().to_owned();
+    if let Some(target_version) = args.get("target") {
+        target = target_version.to_owned();
+    } else {
+        print!("Target sled version [0.34]: ");
+        stdout().flush().unwrap();
+        stdin().read_line(&mut target).unwrap();
+    }
 
     // Default target version
     if target.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
     let mut target = String::new();
 
     let args: BTreeMap<String, String> = env::args()
-        .filter(|arg| arg.starts_with("-"))
+        .filter(|arg| arg.starts_with("--"))
         .map(|arg| {
             arg.splitn(2, '=')
                 .map(ToString::to_string)
@@ -15,7 +15,7 @@ fn main() {
         })
         .fold(BTreeMap::new(), |mut map, arg| {
             if arg.len() != 2 {
-                panic!("Wrong argument! An argument must be of the format 'key=value'");
+                panic!("Wrong argument! An argument must be of the format '--key=value'");
             }
             map.insert(arg[0].trim_start_matches('-').to_owned(), arg[1].to_owned());
             map


### PR DESCRIPTION
This PR adds 3 command line args:
- `--input`: Path to the sled database folder
- `--output`: Path into which the migrated database will be stored
- `--target`: Target version number to which the database will be migrated

I also am adding a `Dockerfile` which can be used to migrate the database of the `Conduit` docker image. I still need to figure out how to replace the old db, but should not be that difficult with a bit of bash-fu.